### PR TITLE
Bugs: non-diagonal scaling matrix

### DIFF
--- a/shry/main.py
+++ b/shry/main.py
@@ -582,11 +582,17 @@ class LabeledStructure(Structure):
         """
 
         scale_matrix = np.array(scaling_matrix, np.int16)
-        #print(scale_matrix)
-        if scale_matrix.shape != (3, 3):
-            scale_matrix = np.array(scale_matrix * np.eye(3), np.int16)
-        #print(scale_matrix)
-        #sys.exit()
+
+        # check the shape of the scaling matrix
+        if not scale_matrix.shape in {(1,), (3,), (3, 3)}:
+            logging.warning("The scale_matrix.shape should be (1,), (3,), or (3, 3)")
+            raise ValueError
+        else:
+            if scale_matrix.shape != (3, 3):
+                scale_matrix = np.array(scale_matrix * np.eye(3), np.int16)
+            else:
+                pass
+
         new_lattice = Lattice(np.dot(scale_matrix, self._lattice.matrix))
 
         f_lat = lattice_points_in_supercell(scale_matrix)

--- a/shry/main.py
+++ b/shry/main.py
@@ -278,7 +278,7 @@ class ScriptHelper:
         string += print_format.format(
             "to_species", ", ".join(map(str, self.to_species))
         )
-        string += print_format.format("scaling_matrix", self.scaling_matrix)
+        string += print_format.format("scaling_matrix", np.array(self.scaling_matrix).flatten())
         string += print_format.format("symmetrize", self.symmetrize)
         string += print_format.format("sample", self.sample)
         string += print_format.format("symprec", self.symprec)
@@ -580,9 +580,13 @@ class LabeledStructure(Structure):
         The parent method returns Structure instance!
         Overwrite the offending line.
         """
+
         scale_matrix = np.array(scaling_matrix, np.int16)
+        #print(scale_matrix)
         if scale_matrix.shape != (3, 3):
             scale_matrix = np.array(scale_matrix * np.eye(3), np.int16)
+        #print(scale_matrix)
+        #sys.exit()
         new_lattice = Lattice(np.dot(scale_matrix, self._lattice.matrix))
 
         f_lat = lattice_points_in_supercell(scale_matrix)

--- a/shry/script.py
+++ b/shry/script.py
@@ -261,6 +261,8 @@ def main():  # pylint: disable=missing-function-docstring
             int(x)
             for x in const.FLEXIBLE_SEPARATOR.split(",".join(args.scaling_matrix))
         ]
+
+        # check the dimension of the scaling matrix
         if not len(scaling_matrix) in {1, 3, 9}:
             logging.warning("The scaling_matrix should be 1, 3, or 9 scalar values.")
             raise ValueError

--- a/shry/script.py
+++ b/shry/script.py
@@ -20,6 +20,8 @@ import argparse
 import datetime
 import fnmatch
 import logging
+import sys
+import numpy as np
 
 import tqdm
 
@@ -126,8 +128,9 @@ def main():  # pylint: disable=missing-function-docstring
         nargs="*",
         type=str,  # To allow flexible separator
         help=(
-            "Three or nine (for non-diagonal supercell) integers specifying "
-            "the scaling matrix for constructing a supercell."
+            "Three (for diagonal supercells) or nine (for non-diagonal supercells) integers specifying "
+            "the scaling matrix for constructing a supercell. One scalar value is also accepted, "
+            "which is converted to three scalar values (e.g., 1 -> 1 1 1)"
         ),
         default=const.DEFAULT_SCALING_MATRIX_STR,
     )
@@ -258,9 +261,19 @@ def main():  # pylint: disable=missing-function-docstring
             int(x)
             for x in const.FLEXIBLE_SEPARATOR.split(",".join(args.scaling_matrix))
         ]
+        if not len(scaling_matrix) in {1, 3, 9}:
+            logging.warning("The scaling_matrix should be 1, 3, or 9 scalar values.")
+            raise ValueError
+        else:
+            if len(scaling_matrix) == 9:
+                scaling_matrix = np.array(scaling_matrix).reshape(3, 3)
+            else:
+                scaling_matrix = np.array(scaling_matrix)
+
         from_species = list(filter(None, from_species))
         to_species = list(filter(None, to_species))
-        scaling_matrix = list(filter(None, scaling_matrix))
+        #scaling_matrix = list(filter(None, scaling_matrix)) #here! the problem is that filter removes 0!
+
         helper = ScriptHelper(
             structure_file=args.input,
             from_species=from_species,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -177,7 +177,47 @@ def test_sequential():
     assert len(list(substitutor.weights())) == 147
 
 @chdir("../examples")
-def test_sequential_scailing_matrix_3_3_3_diagonal():
+def test_sequential_scaling_diagonal_one_scalar_value():
+    """
+    Test sequential use of Substitutor;
+    basically testing the setter of Substitutor.structure
+    """
+    structure = LabeledStructure.from_file("SmFe12.cif")
+    structure1 = structure.copy()
+    structure2 = structure.copy()
+    structure1.replace_species({"Fe1": "Fe7Ti"})
+    structure2.replace_species({"Fe2": "Fe6Ti2"})
+    structure1 *= [2]
+    structure2 *= [2]
+
+    substitutor = Substitutor(structure1)
+    assert substitutor.count() == 17324048
+    substitutor.structure = structure2
+    assert substitutor.count() == 1909076572380
+
+@chdir("../examples")
+def test_sequential_scaling_diagonal_three_scalar_values():
+    """
+    Test sequential use of Substitutor;
+    basically testing the setter of Substitutor.structure
+    """
+    structure = LabeledStructure.from_file("SmFe12.cif")
+    structure1 = structure.copy()
+    structure2 = structure.copy()
+    structure1.replace_species({"Fe1": "Fe7Ti"})
+    structure2.replace_species({"Fe2": "Fe6Ti2"})
+    structure1 *= [1, 2, 1]
+    structure2 *= [1, 2, 1]
+
+    substitutor = Substitutor(structure1)
+    assert substitutor.count() == 11
+    assert len(list(substitutor.weights())) == 11
+    substitutor.structure = structure2
+    assert substitutor.count() == 147
+    assert len(list(substitutor.weights())) == 147
+
+@chdir("../examples")
+def test_sequential_scaling_diagonal_matrix():
     """
     Test sequential use of Substitutor;
     basically testing the setter of Substitutor.structure
@@ -198,7 +238,7 @@ def test_sequential_scailing_matrix_3_3_3_diagonal():
     assert len(list(substitutor.weights())) == 147
 
 @chdir("../examples")
-def test_sequential_scailing_matrix_3_3_3_nondiagonal():
+def test_sequential_scaling_nondiagonal_matrix():
     """
     Test sequential use of Substitutor;
     basically testing the setter of Substitutor.structure

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -176,6 +176,47 @@ def test_sequential():
     assert substitutor.count() == 147
     assert len(list(substitutor.weights())) == 147
 
+@chdir("../examples")
+def test_sequential_scailing_matrix_3_3_3_diagonal():
+    """
+    Test sequential use of Substitutor;
+    basically testing the setter of Substitutor.structure
+    """
+    structure = LabeledStructure.from_file("SmFe12.cif")
+    structure1 = structure.copy()
+    structure2 = structure.copy()
+    structure1.replace_species({"Fe1": "Fe7Ti"})
+    structure2.replace_species({"Fe2": "Fe6Ti2"})
+    structure1 *= [[1, 0, 0],[0, 2, 0],[0, 0, 1]]
+    structure2 *= [[1, 0, 0],[0, 2, 0],[0, 0, 1]]
+
+    substitutor = Substitutor(structure1)
+    assert substitutor.count() == 11
+    assert len(list(substitutor.weights())) == 11
+    substitutor.structure = structure2
+    assert substitutor.count() == 147
+    assert len(list(substitutor.weights())) == 147
+
+@chdir("../examples")
+def test_sequential_scailing_matrix_3_3_3_nondiagonal():
+    """
+    Test sequential use of Substitutor;
+    basically testing the setter of Substitutor.structure
+    """
+    structure = LabeledStructure.from_file("SmFe12.cif")
+    structure1 = structure.copy()
+    structure2 = structure.copy()
+    structure1.replace_species({"Fe1": "Fe7Ti"})
+    structure2.replace_species({"Fe2": "Fe6Ti2"})
+    structure1 *= [[0, 1, 0],[2, 0, 0],[0, 0, 1]]
+    structure2 *= [[0, 1, 0],[2, 0, 0],[0, 0, 1]]
+
+    substitutor = Substitutor(structure1)
+    assert substitutor.count() == 11
+    assert len(list(substitutor.weights())) == 11
+    substitutor.structure = structure2
+    assert substitutor.count() == 147
+    assert len(list(substitutor.weights())) == 147
 
 @chdir("../examples")
 def test_no_disorder():


### PR DESCRIPTION
Dear Genki,

I noticed that the non-diagonal implementation did not work.

`shry -s 2 1 1 --count-only XXXX.cif`

works, but 

`shry -s 1 1 0 -1 1 0 0 0 1 --count-only XXXX.cif`

> scale_matrix = np.array(scale_matrix * np.eye(3), np.int16) # line 587 in main.py
> ValueError: operands could not be broadcast together with shapes (9,) (3,3) 

The problem comes from the built-in filter function at the line 264 of `script.py`

`scaling_matrix = list(filter(None, scaling_matrix))`

because this filters out 0 from the list. Indeed,

```
scaling_matrix = [1, 1, 0, -1, 1, 0, 0, 0, 1]
scaling_matrix = list(filter(None, scaling_matrix))
```

> scaling_matrix -> [1, 1, -1, 1, 1].

So, I have just commented out line 264.

By the way, there are only three possibilities for the input.

1. One scalar value
2. Three scalar values
3. Three vectors (9 scalar values) 

So, I have introduced lines  into `script.py` and `main.py` for checking the dimension of the scaling matrix.

e.g., `script.py`
```
scaling_matrix = [
    int(x)
    for x in const.FLEXIBLE_SEPARATOR.split(",".join(args.scaling_matrix))
]

if not len(scaling_matrix) in {1,3,9}:
    logging.warning("The scaling_matrix should be 1, 3, or 9 scalar values.")
    raise ValueError
 
else:
    if len(scaling_matrix) == 9:
        scaling_matrix = np.array(scaling_matrix).reshape(3,3)
    else:
        scaling_matrix = np.array(scaling_matrix)
```