### PR TITLE
Updated SHRY. Fixed the bug reported in the discussion #12

### DIFF
--- a/.github/workflows/shry-pytest.yml
+++ b/.github/workflows/shry-pytest.yml
@@ -6,6 +6,8 @@ name: SHRY pytest
 on:
   push:
     branches: [ "master", "devel" ]
+  pull_request:
+    branches: [ "main", "devel" ]
 
 jobs:
   build:
@@ -25,7 +27,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
-        python -m pip install .    
+        python -m pip install .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -34,6 +36,6 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest
+        pytest -v
 
 

--- a/shry/script.py
+++ b/shry/script.py
@@ -196,7 +196,7 @@ def main():  # pylint: disable=missing-function-docstring
     group.add_argument(
         "--atol",
         type=float,
-        default=const.DEFAULT_SYMPREC,
+        default=const.DEFAULT_ATOL,
         help="Discretization absolute tolerance (angstrom).",
     )
     group.add_argument(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -23,11 +23,13 @@ from shry.core import (
     TooBigError,
 )
 from shry.main import LabeledStructure, ScriptHelper
+from shry import const
 from helper import chdir
 
 # Tolerances
-SHRY_TOLERANCE = 0.01  # angstrom
-SHRY_ANGLE_TOLERANCE = 5.0  # degree
+SHRY_TOLERANCE = const.DEFAULT_SYMPREC
+SHRY_ANGLE_TOLERANCE = const.DEFAULT_ANGLE_TOLERANCE
+SHRY_ATOL = const.DEFAULT_ATOL
 
 # PatternMaker basic functions.
 
@@ -510,6 +512,7 @@ def test_benchmark():
             structure,
             symprec=SHRY_TOLERANCE,
             angle_tolerance=SHRY_ANGLE_TOLERANCE,
+            atol=SHRY_ATOL
         )
         count_obtained = s.count()
         count_ref = equivalent


### PR DESCRIPTION
I have fixed the bug reported in the discussion #12.

- Added `atol` to the `np.isclose` calls in `core.py`. The default value was `atol=1e-8` -> `atol=const.DEFAULT_ATOL` or `atol =  self._atol`.
- Introduced `max_denominator=int(1 / const.DEFAULT_ATOL)` argument to `to_int_dict` and `inted_composition` methods in the `core.py` module.
- SHRY prints comments about the choice of `atol` (i.e., precision) if one comes across an error related to this.
- Change the default `--atol` value in the `script.py`. `default=const.DEFAULT_SYMPREC` -> `default=const.DEFAULT_ATOL`. Is it a bug? 
- Updated `test_core.py` triggered by `pytest` such that it uses the default values for `SYMPREC`, `ANGLE_TOLERANCE`, and `ATOL`.
- A GitHub action (`shry-pytest.yml`) is triggered also by a pull-request.
- Added a new meta-programing line for the `Composition.formula` property to use our tolerance (`atol`).